### PR TITLE
Remove italics from 'distraite'

### DIFF
--- a/src/epub/text/chapter-29.xhtml
+++ b/src/epub/text/chapter-29.xhtml
@@ -40,7 +40,7 @@
 			<p>Katherine looked round quickly and then turned back again.</p>
 			<p>“He is with <abbr epub:type="z3998:name-title">Mr.</abbr> Van Aldin,” continued Lenox. “There is something I want to ask Major Knighton about. I won’t be a minute.”</p>
 			<p>Left alone together, Poirot bent forward and murmured to Katherine:</p>
-			<p>“You are <i xml:lang="fr">distraite</i>, Mademoiselle; your thoughts, they are far away, are they not?”</p>
+			<p>“You are distraite, Mademoiselle; your thoughts, they are far away, are they not?”</p>
 			<p>“Just as far as England, no farther.”</p>
 			<p>Guided by a sudden impulse, she took the letter she had received that morning and handed it across to him to read.</p>
 			<p>“That is the first word that has come to me from my old life; somehow or other⁠—it hurts.”</p>


### PR DESCRIPTION
The italicization in the SE release for this word was inconsistent, with `distraite` not italicized in Chapter 28, but italicized and marked up as French in Chapter 29.